### PR TITLE
Tasks # 1,2,3 and 5

### DIFF
--- a/src/locales/default.js
+++ b/src/locales/default.js
@@ -776,6 +776,7 @@ const strings = {
   disable_recovery_popup_message: 'This account already has password recovery setup. Would you like to disable it?',
   error_disabling_recovery: 'Error disabling recovery',
   recovery_disabled: 'Recovery Disabled',
+  recovery_setup_successful: 'Password recovery setup complete. Please ensure you retain a copy of the email you sent yourself. Use the link in the email to recovery your account if your password is forgotten.',
   in: 'in',
 
     //  SSO

--- a/src/modules/Login/Login.web.jsx
+++ b/src/modules/Login/Login.web.jsx
@@ -23,7 +23,7 @@ class Login extends Component {
       this.refs.loginUsername.getWrappedInstance().blur()
       this.refs.password.getWrappedInstance().blur()
       this.props.dispatch(loginWithPassword(this.props.username, this.props.password, success => {
-        if(success) browserHistory.push('/passwordRecovery')
+        if(success) browserHistory.push('/home')
       }))
     } else {
       this.props.dispatch(openLogin())

--- a/src/modules/Login/Login.web.jsx
+++ b/src/modules/Login/Login.web.jsx
@@ -23,7 +23,7 @@ class Login extends Component {
       this.refs.loginUsername.getWrappedInstance().blur()
       this.refs.password.getWrappedInstance().blur()
       this.props.dispatch(loginWithPassword(this.props.username, this.props.password, success => {
-        if(success) browserHistory.push('/home')
+        if(success) browserHistory.push('/passwordRecovery')
       }))
     } else {
       this.props.dispatch(openLogin())
@@ -105,7 +105,7 @@ class Login extends Component {
                 flexDirection: 'column',
                 justifyContent: 'center',
                 alignItems: 'center',
-                opacity: opacityFieldsView, 
+                opacity: opacityFieldsView,
                 height: heightFieldsView
               }}>
             <Input

--- a/src/modules/Login/LoginWithPin.web.jsx
+++ b/src/modules/Login/LoginWithPin.web.jsx
@@ -21,7 +21,7 @@ class Login extends Component {
         this.props.pin
       , success => {
         if(success) {
-          browserHistory.push('/home')
+          browserHistory.push('/passwordRecovery')
         } else {
           is.refs.pinInput.getWrappedInstance().focus()
         }
@@ -96,7 +96,7 @@ class Login extends Component {
 
     return (
       <div style={{padding: '0 0.8em',display:'flex',flexDirection:'column', justifyContent: 'center', alignItems:'center'}}>
-        <Button raised neutral style={{textTransform: 'none', margin: '10px 0px'}} onClick={this.toggleCachedUsers}>
+        <Button flat primary style={{textTransform: 'none', margin: '10px 0px'}} onClick={this.toggleCachedUsers}>
           { this.props.user ? this.props.user : 'No User Selected' }
         </Button>
 
@@ -125,7 +125,7 @@ class Login extends Component {
           />
         </div>
 
-        <Button raised neutral style={{margin: '10px 0px'}} onClick={this.viewPasswordInput}>
+        <Button flat primary style={{margin: '10px 0px'}} onClick={this.viewPasswordInput}>
           { t('fragment_landing_switch_user') }
         </Button>
         {cUsers()}

--- a/src/modules/Login/LoginWithPin.web.jsx
+++ b/src/modules/Login/LoginWithPin.web.jsx
@@ -21,7 +21,7 @@ class Login extends Component {
         this.props.pin
       , success => {
         if(success) {
-          browserHistory.push('/passwordRecovery')
+          browserHistory.push('/home')
         } else {
           is.refs.pinInput.getWrappedInstance().focus()
         }
@@ -96,7 +96,7 @@ class Login extends Component {
 
     return (
       <div style={{padding: '0 0.8em',display:'flex',flexDirection:'column', justifyContent: 'center', alignItems:'center'}}>
-        <Button flat primary style={{textTransform: 'none', margin: '10px 0px'}} onClick={this.toggleCachedUsers}>
+        <Button flat neutral style={{textTransform: 'none', margin: '10px 0px'}} onClick={this.toggleCachedUsers}>
           { this.props.user ? this.props.user : 'No User Selected' }
         </Button>
 
@@ -125,7 +125,7 @@ class Login extends Component {
           />
         </div>
 
-        <Button flat primary style={{margin: '10px 0px'}} onClick={this.viewPasswordInput}>
+        <Button flat neutral style={{margin: '10px 0px'}} onClick={this.viewPasswordInput}>
           { t('fragment_landing_switch_user') }
         </Button>
         {cUsers()}

--- a/src/modules/PasswordRecovery/PasswordRecovery.web.js
+++ b/src/modules/PasswordRecovery/PasswordRecovery.web.js
@@ -25,7 +25,7 @@ class PasswordRecovery extends Component {
           dispatch(action.hidePasswordRecoveryView())
         }
         if(!error){
-          const questions = results.filter( result => result.category === 'recovery2' ).map( result => result.question ) 
+          const questions = results.filter( result => result.category === 'recovery2' ).map( result => result.question )
           dispatch(action.setPasswordRecoveryQuestions(questions))
         }
       })
@@ -41,7 +41,7 @@ class PasswordRecovery extends Component {
             this.props.secondQuestion
           ],
           answers       : [
-            this.props.firstAnswer, 
+            this.props.firstAnswer,
             this.props.secondAnswer
           ],
           password      : this.props.password,
@@ -88,8 +88,8 @@ class PasswordRecovery extends Component {
 
   _renderQuestions = () => {
     return this.props.questions.map( (question, index) => {
-      return <option key={index} value={question}>{question}</option> 
-    }) 
+      return <option key={index} value={question}>{question}</option>
+    })
   }
 
   render () {
@@ -102,16 +102,16 @@ class PasswordRecovery extends Component {
             </select>
           </div>
           <div>
-            <input type="text" name="firstAnswer" onChange={this._handleOnChangeFirstAnswer} value={this.props.firstAnswer} placeholder="First Question Answer" required/>	
+            <input type="text" name="firstAnswer" onChange={this._handleOnChangeFirstAnswer} value={this.props.firstAnswer} placeholder="First Question Answer" required/>
           </div>
             <select onChange={this._handleOnChangeSecondQuestion} value={this.props.secondQuestion} required>
               {this._renderQuestions()}
             </select>
           <div>
-            <input type="text" name="secondAnswer" onChange={this._handleOnChangeSecondAnswer} value={this.props.secondAnswer} placeholder="Second Question Answer" required/>	
+            <input type="text" name="secondAnswer" onChange={this._handleOnChangeSecondAnswer} value={this.props.secondAnswer} placeholder="Second Question Answer" required/>
           </div>
           <div>
-            <input type="password" name="recoveryPassword" onChange={this._handleOnChangePassword} value={this.props.password} placeholder="Password" required/>	
+            <input type="password" name="recoveryPassword" onChange={this._handleOnChangePassword} value={this.props.password} placeholder="Password" required/>
           </div>
           <div>
             <button type="button" onClick={this._handleSubmit}>Submit</button>
@@ -128,10 +128,10 @@ class PasswordRecovery extends Component {
     }
     if(!this.props.view && this.props.viewToken){
       return(
-        <PasswordRecoveryToken 
+        <PasswordRecoveryToken
           handleOnChangeEmail={this._handleOnChangeEmail}
           email={this.props.email}
-          token={this.props.token}          
+          token={this.props.token}
           username={this.props.account.username}
           dispatch={this.props.dispatch}
           finishButton={this.props.finishButton}

--- a/src/modules/PasswordRecovery/PasswordRecoveryToken.web.js
+++ b/src/modules/PasswordRecovery/PasswordRecoveryToken.web.js
@@ -7,6 +7,7 @@ import abcctx from '../../lib/web/abcContext'
 import { passwordRecoveryDone } from './PasswordRecovery.action'
 import { openErrorModal } from '../ErrorModal/ErrorModal.action'
 import { checkEmail } from './PasswordRecovery.middleware'
+import ErrorModal from '../ErrorModal/ErrorModal.web'
 
 export default class PasswordRecovery extends Component {
 
@@ -22,32 +23,33 @@ export default class PasswordRecovery extends Component {
         this.props.username,
         callback
       )
-    )  
+    )
   }
-       
+
   _handleClose = () => {
+    this.props.dispatch(openErrorModal(t('recovery_setup_successful')))
     this.props.dispatch(passwordRecoveryDone())
   }
-  
+
   _renderFinishButton = () => {
     if(this.props.finishButton){
       return (
         <div>
           <button type="button" onClick={this._handleClose}>Done</button>
         </div>
-      ) 
+      )
     }else{
-      return null 
+      return null
     }
   }
-  
+
   render () {
     return (
       <div>
         <p>{t('save_recovery_token_popup')}</p>
         <p>{t('save_recovery_token_popup_message')}</p>
         <div>
-          <input type="email" name="" onChange={this.props.handleOnChangeEmail} value={this.props.email} placeholder="Email Address"/>	
+          <input type="email" name="" onChange={this.props.handleOnChangeEmail} value={this.props.email} placeholder="Email Address"/>
         </div>
         <div>
           <button type="button" onClick={() => this._handleSubmit('google')}>Send using Gmail</button>
@@ -62,6 +64,7 @@ export default class PasswordRecovery extends Component {
           <button type="button" onClick={() => this._handleSubmit('generic')}>Send using Email App</button>
         </div>
         {this._renderFinishButton()}
+        <ErrorModal />
       </div>
     )
   }

--- a/src/modules/ReviewDetails/ReviewDetails.web.jsx
+++ b/src/modules/ReviewDetails/ReviewDetails.web.jsx
@@ -32,9 +32,9 @@ class Review extends Component {
     const { username, password } = this.props.details
     this.props.dispatch(
       loginWithPassword(
-        username, 
-        password, 
-        () => browserHistory.push('/home')
+        username,
+        password,
+        () => browserHistory.push('/passwordRecovery')
       )
     )
   }
@@ -45,9 +45,9 @@ class Review extends Component {
         <div>
           <Card>
             <CardText style={{height: '100px'}}>
-              <p>username: {this.props.details.username}</p> 
-              <p>pin: {this.props.details.pin}</p> 
-              <p>password: {this.props.details.password}</p> 
+              <p>username: {this.props.details.username}</p>
+              <p>pin: {this.props.details.pin}</p>
+              <p>password: {this.props.details.password}</p>
             </CardText>
             <CardActions>
               <Button type="button" raised primary onClick={this._handleHideDetails}>{t('fragment_setup_writeitdown_hide')}</Button>
@@ -67,8 +67,8 @@ class Review extends Component {
         <div>
           <Card>
             <CardText style={{height: '100px'}}>
-              <h5>{t('fragment_setup_writeitdown_text')}</h5> 
-              <p>{t('fragment_setup_writeitdown_text_warning')}</p> 
+              <h5>{t('fragment_setup_writeitdown_text')}</h5>
+              <p>{t('fragment_setup_writeitdown_text_warning')}</p>
             </CardText>
             <CardActions>
               <Button type="button" raised primary onClick={this._handleShowDetails}>{t('fragment_setup_writeitdown_show')}</Button>

--- a/src/modules/ReviewDetails/ReviewDetails.web.jsx
+++ b/src/modules/ReviewDetails/ReviewDetails.web.jsx
@@ -34,7 +34,7 @@ class Review extends Component {
       loginWithPassword(
         username,
         password,
-        () => browserHistory.push('/passwordRecovery')
+        () => browserHistory.push('/home')
       )
     )
   }


### PR DESCRIPTION
1. After account creation, popup setup password recovery window. After the signup, right now we are taking them to the "manage account" screen, instead let's take them directly to the recovery setup screen. The link for account recovery can be found on the home screen. 
2.  Change Exit PIN Login (on login screen) to just be blue clickable text without button frame. To reach PIN login screen, login with username and password once, press log out/restart app. DO NOT use underline on the link. Make sure that it still has padding, so that clicking just outside of the text still produces the desired result. In other words...still a button, but no frame.
3.  Again on PIN login screen, Change the current username  to be just blue clickable text without button frame. Again, no underline, and same padding thing.
5. Add modal popup after setting password recovery. "Password recovery setup complete. Please ensure you retain a copy of the email you sent yourself. Use the link in the email to recovery your account if your password is forgotten.". Don't forget to use the locales/default.js. Check "ErrorModal" component we already created for this purpose. you can probably just use it as is.